### PR TITLE
Switch to backward Euler for source solve

### DIFF
--- a/src/five_moment/dg_solution_helper.cc
+++ b/src/five_moment/dg_solution_helper.cc
@@ -77,8 +77,6 @@ double FiveMomentDGSolutionHelper<dim>::compute_global_error(
     LinearAlgebra::distributed::Vector<double>& solution, 
     Function<dim>& f,
     unsigned int component) {
-    AssertThrow(f.n_components == 5, 
-            ExcMessage("The function provided to compare against must have 5 components."));
     Vector<double> difference;
     auto select = ComponentSelectFunction<dim, double>(component, discretization->get_n_components());
     VectorTools::integrate_difference(

--- a/src/five_moment/explicit_source_operator.cc
+++ b/src/five_moment/explicit_source_operator.cc
@@ -137,7 +137,6 @@ void FiveMomentExplicitSourceOperator<dim>::local_apply_cell(
                 if (!(*species[i]->general_source_term).is_zero) {
                     const auto p = phi.quadrature_point(q);
                     const auto source_val = evaluate_function<dim, 5>(*species[i]->general_source_term, p);
-                    SHOW(source_val);
                     phi.submit_value(source_val, q);
                 }
             }

--- a/src/five_moment/five_moment.h
+++ b/src/five_moment/five_moment.h
@@ -163,7 +163,7 @@ std::unique_ptr<FiveMomentApp<dim>> FiveMomentApp<dim>::create_from_parameters(
         prm.leave_subsection();
     }
     auto fields = PHMaxwellFields<dim>::create_from_parameters(
-            prm, n_boundaries, plasma_norm);
+            input, n_boundaries, plasma_norm);
 
     auto grid = Grid<dim>::create_from_parameters(prm, 
             std::static_pointer_cast<GridExtension<dim>>(ext));

--- a/src/five_moment/implicit_source_operator.cc
+++ b/src/five_moment/implicit_source_operator.cc
@@ -107,14 +107,14 @@ void FiveMomentImplicitSourceOperator<dim>::local_apply_cell(
 
                     L.fill(omega_p_tau_scaling, 3 + 3 * i, 0, 0, 0, rho_i * Z_i * Z_i / A_i / A_i);
                     L.fill(IxB, 3 + 3 * i, 3 + 3 * i, 0, 0,
-                           omega_c_tau * Z_i / A_i);
+                           rho_i * omega_c_tau * Z_i / A_i / A_i);
                 }
 
                 M.reinit(3 * n_species + 3);
                 for (unsigned int i = 0; i < 3 * n_species + 3; i++) {
                     M(i, i) += 1.0;
                 }
-                M.add(-dt / 2.0, L);
+                M.add(-dt, L);
                 M.compute_lu_factorization();
 
                 // Form Vector that contains the RHS
@@ -148,7 +148,7 @@ void FiveMomentImplicitSourceOperator<dim>::local_apply_cell(
 
             field_vals = fields_eval.get_dof_value(dof);
             for (unsigned int d = 0; d < 3; d++) {
-                field_vals[d] = 2.0 * E_n_plus_1_2[d] - field_vals[d];
+                field_vals[d] = 1.0 * E_n_plus_1_2[d] - 0.0*field_vals[d];
             }
             fields_eval.submit_dof_value(field_vals, dof);
 
@@ -158,7 +158,7 @@ void FiveMomentImplicitSourceOperator<dim>::local_apply_cell(
                 VectorizedArray<double> new_KE = VectorizedArray(0.0);
                 for (unsigned int d = 0; d < 3; d++) {
                     old_KE += 0.5 * species_vals[d+1] * species_vals[d+1] / species_vals[0];
-                    species_vals[d+1] = 2.0 * rhou_n_plus_1_2[i][d] - species_vals[d+1];
+                    species_vals[d+1] = 1.0 * rhou_n_plus_1_2[i][d] - 0.0*species_vals[d+1];
                     new_KE += 0.5 * species_vals[d+1] * species_vals[d+1] / species_vals[0];
                 }
                 VectorizedArray<double> internal_energy = species_vals[4] - old_KE;

--- a/src/maxwell/fields.cc
+++ b/src/maxwell/fields.cc
@@ -51,20 +51,22 @@ void PHMaxwellFields<dim>::declare_parameters(ParameterHandler &prm,
 
 template <int dim>
 std::shared_ptr<PHMaxwellFields<dim>>
-PHMaxwellFields<dim>::create_from_parameters(ParameterHandler &prm,
+PHMaxwellFields<dim>::create_from_parameters(SimulationInput &input,
                                              unsigned int n_boundaries,
                                              PlasmaNormalization plasma_norm) {
+    ParameterHandler& prm = input.prm;
+
     prm.enter_subsection("PHMaxwellFields");
 
     double phmaxwell_gamma = prm.get_double("phmaxwell_gamma");
     double phmaxwell_chi = prm.get_double("phmaxwell_chi");
 
     prm.enter_subsection("InitialCondition");
-    const auto ic = PHMaxwellFunc<dim>::create_from_parameters(prm);
+    const auto ic = PHMaxwellFunc<dim>::create_from_parameters(input);
     prm.leave_subsection();
 
     prm.enter_subsection("GeneralSourceTerm");
-    const auto source = PHMaxwellFunc<dim>::create_from_parameters(prm);
+    const auto source = PHMaxwellFunc<dim>::create_from_parameters(input);
     prm.leave_subsection();
 
     MaxwellBCMap<dim> bc_map;
@@ -79,7 +81,7 @@ PHMaxwellFields<dim>::create_from_parameters(ParameterHandler &prm,
             bc_map.set_perfect_conductor_boundary(boundary_id);
         } else if (bc_type == "Dirichlet") {
             prm.enter_subsection("DirichletFunction");
-            auto func = PHMaxwellFunc<dim>::create_from_parameters(prm);
+            auto func = PHMaxwellFunc<dim>::create_from_parameters(input);
             prm.leave_subsection();
             bc_map.set_dirichlet_boundary(boundary_id, std::move(func));
         }

--- a/src/maxwell/fields.h
+++ b/src/maxwell/fields.h
@@ -33,7 +33,7 @@ class PHMaxwellFields {
     static void declare_parameters(ParameterHandler& prm,
             unsigned int n_boundaries);
 
-    static std::shared_ptr<PHMaxwellFields> create_from_parameters(ParameterHandler &prm, 
+    static std::shared_ptr<PHMaxwellFields> create_from_parameters(SimulationInput &input, 
             unsigned int n_boundaries,
             PlasmaNormalization plasma_norm);
 

--- a/src/maxwell/maxwell_app.cc
+++ b/src/maxwell/maxwell_app.cc
@@ -67,7 +67,7 @@ std::unique_ptr<PHMaxwellApp<dim>> PHMaxwellApp<dim>::create_from_parameters(
     PlasmaNormalization plasma_norm =
         PlasmaNormalization::create_from_parameters(input);
     auto fields = PHMaxwellFields<dim>::create_from_parameters(
-        prm, n_boundaries, plasma_norm);
+        input, n_boundaries, plasma_norm);
     auto grid = Grid<dim>::create_from_parameters(
         prm, std::make_shared<GridExtension<dim>>());
 

--- a/src/maxwell/phmaxwell_func.cc
+++ b/src/maxwell/phmaxwell_func.cc
@@ -33,7 +33,7 @@ The spatial coordinates are defined as variables `x, y, z`, and time as the vari
 
 template <int dim>
 PHMaxwellFunc<dim> PHMaxwellFunc<dim>::create_from_parameters(
-    ParameterHandler& prm) {
+    SimulationInput& input) {
     std::map<std::string, double> constants;
     constants["pi"] = numbers::PI;
 
@@ -52,8 +52,8 @@ PHMaxwellFunc<dim> PHMaxwellFunc<dim>::create_from_parameters(
             AssertThrow(false, ExcNotImplemented());
             break;
     }
-    std::string expression = prm.get("components");
-    std::string constants_list = prm.get("constants");
+    std::string expression = input.get_with_subexpression_substitutions("components");
+    std::string constants_list = input.get_with_subexpression_substitutions("constants");
 
     std::vector<std::string> const_list =
         Utilities::split_string_list(constants_list, ',');

--- a/src/maxwell/phmaxwell_func.h
+++ b/src/maxwell/phmaxwell_func.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <deal.II/base/parsed_function.h>
+#include "simulation_input.h"
 
 using namespace dealii;
 
@@ -12,7 +13,7 @@ class PHMaxwellFunc {
         func(func), is_zero(is_zero) {}
 
     static void declare_parameters(ParameterHandler &prm);
-    static PHMaxwellFunc<dim> create_from_parameters(ParameterHandler &prm);
+    static PHMaxwellFunc<dim> create_from_parameters(SimulationInput &input);
 
     std::shared_ptr<FunctionParser<dim>> func;
     bool is_zero;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SOURCES
     timestepper_test.cc
     euler_test.cc
     conservation_test.cc
+    current_drive_test.cc
     dof_utils_test.cc
     plasma_waves_test.cc
     shock_capturing_fv_test.cc

--- a/test/current_drive_test.cc
+++ b/test/current_drive_test.cc
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+#include "warpii.h"
+#include "src/five_moment/five_moment.h"
+
+using namespace warpii;
+using namespace warpii::five_moment;
+
+TEST(CurrentDriveTest, RampsUpToCurrent) {
+    int argc = 0;
+    char** argv = nullptr;
+    Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+    std::string input = R"(
+set Application = FiveMoment
+set n_dims = 1
+set fe_degree = 1
+
+subsection geometry
+    set left = 0
+    set right = 1
+    set nx = 1
+end
+
+set n_species = 2
+set n_boundaries = 0
+
+subsection Species_0
+    set name = electron
+    set mass = 0.04
+    set charge = -1.0
+    subsection InitialCondition
+        set components = 4; 0; 0; 0; .01
+    end
+end
+
+subsection Species_1
+    set name = ion
+    set mass = 1.0
+    set charge = 1.0
+    subsection InitialCondition
+        set components = 100; 0; 0; 0; .01
+    end
+end
+
+subsection Normalization
+    set omega_p_tau = 100
+end
+
+subsection PHMaxwellFields
+    set phmaxwell_chi = 0
+    set phmaxwell_gamma = 0
+    subsection GeneralSourceTerm
+        set components = 100 * min(.78, .78 * t / 40); 0; 0; 0; 0; 0; 0; 0
+    end
+end
+
+set t_end = 60.0
+)";
+
+    Warpii warpii_obj;
+    warpii_obj.input = input;
+    warpii_obj.opts.fpe = true;
+
+    warpii_obj.run();
+
+    auto& app = warpii_obj.get_app<five_moment::FiveMomentApp<1>>();
+    auto& soln = app.get_solution();
+    auto& helper = app.get_solution_helper();
+
+    FunctionParser<1> rho_u_expected = FunctionParser<1>(
+    "0; 0.75 * 0.04 / -1; 0; 0; 0;"
+    "0; 0.03 * 1 / 1; 0; 0; 0;"
+    "0; 0; 0; 0; 0; 0; 0; 0"
+    );
+    
+    double rho_u_e_error = helper.compute_global_error(soln.mesh_sol, 
+            rho_u_expected, 1);
+    double rho_u_i_error = helper.compute_global_error(soln.mesh_sol, 
+            rho_u_expected, 6);
+
+    EXPECT_NEAR(rho_u_e_error, 0.0, 1e-15);
+    EXPECT_NEAR(rho_u_i_error, 0.0, 1e-15);
+}


### PR DESCRIPTION
The point of this is that I want to use a source term for E_x to model a curl B term, and for that you need a solver that is L stable and can nicely resolve a steady state solution. The implicit midpoint doesn't work at all for obtaining the steady state, especially with variable dt.

The long-term solution here is to bring the general source term inside of the implicit solver. For this we'll want to let the user specify the splitting strategy they want between flux and source terms.