### PR TITLE
Add option to explicitly couple fields and fluids

### DIFF
--- a/include/five_moment/extension.h
+++ b/include/five_moment/extension.h
@@ -78,6 +78,8 @@ class Extension : public virtual warpii::Extension,
 
     }
 
+    virtual void set_time(double t);
+
     virtual void declare_source_parameters(ParameterHandler& prm,
             unsigned int species_index);
 
@@ -245,6 +247,9 @@ Tensor<1, 5, VectorizedArray<double>> Extension<dim>::boundary_flux( \
 
 N_SPECIES_IMPLS(1)
 N_SPECIES_IMPLS(2)
+
+template <int dim>
+void Extension<dim>::set_time(double ) {}
 
 template <int dim>
 void Extension<dim>::declare_bc_parameters(ParameterHandler&, 

--- a/src/five_moment/dg_solver.cc
+++ b/src/five_moment/dg_solver.cc
@@ -29,12 +29,17 @@ void FiveMomentDGSolver<dim>::solve(TimestepCallback writeout_callback,
         TimestepCallback diagnostic_callback) {
     auto step = [&](double t, double dt) -> bool {
         TimestepRequest request(dt, true);
+
+        extension->set_time(t);
+
         const TimestepResult result = ssp_integrator->evolve_one_time_step(
                 explicit_operator, solution, request, t);
         if (!result.successful) {
             return false;
         }
-        implicit_source_operator.evolve_one_time_step(solution.mesh_sol, result.achieved_dt);
+        if (!explicit_fluid_field_coupling) {
+            implicit_source_operator.evolve_one_time_step(solution.mesh_sol, result.achieved_dt);
+        }
 
         std::cout << "t = " << t << std::endl;
         return true;

--- a/src/five_moment/dg_solver.h
+++ b/src/five_moment/dg_solver.h
@@ -60,17 +60,20 @@ class FiveMomentDGSolver {
         double t_end,
         unsigned int n_boundaries,
         bool fields_enabled,
+        bool explicit_fluid_field_coupling,
         const std::string& integrator_type)
         : t_end(t_end),
+        extension(extension),
           discretization(discretization),
           solution_helper(species.size(), discretization),
           species(species),
           fields(fields),
           explicit_operator(extension, discretization, gas_gamma, species, 
-                  fields, plasma_norm, fields_enabled),
+                  fields, plasma_norm, fields_enabled, explicit_fluid_field_coupling),
           implicit_source_operator(plasma_norm, species, discretization, fields_enabled),
           n_boundaries(n_boundaries),
           fields_enabled(fields_enabled),
+          explicit_fluid_field_coupling(explicit_fluid_field_coupling),
           ssp_integrator(create_integrator<dim>(integrator_type))
         {}
 
@@ -88,6 +91,7 @@ class FiveMomentDGSolver {
 
    private:
     double t_end;
+    std::shared_ptr<five_moment::Extension<dim>> extension;
     std::shared_ptr<NodalDGDiscretization<dim>> discretization;
     FiveMomentDGSolutionHelper<dim> solution_helper;
     std::vector<std::shared_ptr<Species<dim>>> species;
@@ -98,6 +102,7 @@ class FiveMomentDGSolver {
     FiveMomentImplicitSourceOperator<dim> implicit_source_operator;
     unsigned int n_boundaries;
     bool fields_enabled;
+    bool explicit_fluid_field_coupling;
     std::shared_ptr<SSPRKIntegrator<FiveMSolutionVec, FiveMomentExplicitOperator<dim>>> ssp_integrator;
 };
 

--- a/src/five_moment/explicit_operator.cc
+++ b/src/five_moment/explicit_operator.cc
@@ -52,6 +52,7 @@ double FiveMomentExplicitOperator<dim>::recommend_dt(const MatrixFree<dim>& mf, 
     if (fields_enabled) {
         dt = std::min(dt, maxwell_flux.recommend_dt(mf, soln));
     }
+    dt = std::min(dt, explicit_sources.recommend_dt(mf, soln));
     return dt;
 }
 

--- a/src/five_moment/explicit_operator.h
+++ b/src/five_moment/explicit_operator.h
@@ -22,11 +22,13 @@ class FiveMomentExplicitOperator : public ForwardEulerOperator<FiveMSolutionVec>
             std::vector<std::shared_ptr<Species<dim>>> species,
             std::shared_ptr<PHMaxwellFields<dim>> fields,
             PlasmaNormalization plasma_norm,
-            bool fields_enabled
+            bool fields_enabled,
+            bool explicit_fluid_field_coupling
                 ):
             fields_enabled(fields_enabled),
             fluid_flux(extension, discretization, gas_gamma, species, fields_enabled),
-            explicit_sources(extension, discretization, species, fields, plasma_norm, fields_enabled),
+            explicit_sources(extension, discretization, species, fields, plasma_norm, fields_enabled,
+                    explicit_fluid_field_coupling),
             maxwell_flux(discretization, 5*species.size(), fields)
         {}
 

--- a/src/five_moment/explicit_source_operator.h
+++ b/src/five_moment/explicit_source_operator.h
@@ -21,13 +21,15 @@ class FiveMomentExplicitSourceOperator
         std::vector<std::shared_ptr<Species<dim>>> species,
         std::shared_ptr<PHMaxwellFields<dim>> fields,
         PlasmaNormalization plasma_norm,
-        bool fields_enabled)
+        bool fields_enabled,
+        bool explicit_fluid_field_coupling)
         : extension(extension),
           discretization(discretization),
           species(species),
           fields(fields),
           plasma_norm(plasma_norm),
-          fields_enabled(fields_enabled)
+          fields_enabled(fields_enabled),
+          explicit_fluid_field_coupling(explicit_fluid_field_coupling)
     {}
 
     TimestepResult perform_forward_euler_step(
@@ -35,6 +37,8 @@ class FiveMomentExplicitSourceOperator
         std::vector<FiveMSolutionVec> &sol_registers, const TimestepRequest dt,
         const double t, 
         const double b=0.0, const double a=1.0, const double c=1.0) override;
+
+    double recommend_dt(const MatrixFree<dim>& mf, const FiveMSolutionVec &soln);
 
    private:
     void local_apply_inverse_mass_matrix(
@@ -56,6 +60,7 @@ class FiveMomentExplicitSourceOperator
     std::shared_ptr<PHMaxwellFields<dim>> fields;
     PlasmaNormalization plasma_norm;
     bool fields_enabled;
+    bool explicit_fluid_field_coupling;
 };
 
 }  // namespace five_moment

--- a/src/five_moment/five_moment.h
+++ b/src/five_moment/five_moment.h
@@ -133,6 +133,7 @@ The components are
 where `phi` and `psi` are the scalar divergence error indicators for Gauss's law and the div-B law,
 as used in the perfectly hyperbolic Maxwell's equation system.
             )");
+    prm.declare_entry("explicit_fluid_field_coupling", "false", Patterns::Bool());
     prm.declare_entry("gas_gamma", "1.6666666666667", Patterns::Double(),
             R"(The gas gamma, AKA the ratio of specific heats, AKA `(n_dims+2)/2` for a plasma.
 Defaults to 5/3, the value for simple ions with 3 degrees of freedom.)");
@@ -176,6 +177,7 @@ std::unique_ptr<FiveMomentApp<dim>> FiveMomentApp<dim>::create_from_parameters(
     unsigned int fe_degree = prm.get_integer("fe_degree");
     std::string fields_enabled_str = prm.get("fields_enabled");
     bool fields_enabled = (fields_enabled_str == "true" || (fields_enabled_str == "auto" && n_species > 1));
+    bool explicit_fluid_field_coupling = prm.get_bool("explicit_fluid_field_coupling");
 
     unsigned int n_field_components = fields_enabled ? 8 : 0;
     unsigned int n_components = n_species * 5 + n_field_components;
@@ -190,7 +192,7 @@ std::unique_ptr<FiveMomentApp<dim>> FiveMomentApp<dim>::create_from_parameters(
 
     auto dg_solver = std::make_unique<FiveMomentDGSolver<dim>>(
         ext, discretization, species, fields, plasma_norm, gas_gamma, 
-        t_end, n_boundaries, fields_enabled, integrator_type);
+        t_end, n_boundaries, fields_enabled, explicit_fluid_field_coupling, integrator_type);
 
 
     auto app = std::make_unique<FiveMomentApp<dim>>(ext, discretization, species,

--- a/src/five_moment/fluid_flux_es_dgsem_operator.h
+++ b/src/five_moment/fluid_flux_es_dgsem_operator.h
@@ -796,7 +796,10 @@ bool FluidFluxESDGSEMOperator<dim>::check_if_solution_is_positive(
             for (unsigned int lane = 0; lane < VectorizedArray<double>::size(); lane++) {
                 if (cell_avg[0][lane] < 0.0 || pressure[lane] < 1e-13) {
                     std::cout << "cell = " << cell << std::endl;
-                    std::cout << "location = " << phi.quadrature_point(0)[0][lane] << ", " << phi.quadrature_point(0)[1][lane] << std::endl;
+                    std::cout << "location = ";
+                    for (unsigned int d = 0; d < dim; d++) {
+                        std::cout << phi.quadrature_point(0)[d][lane] << ", ";
+                    }
                     std::cout << "cell_avg = " << cell_avg << std::endl;
                     std::cout << "pressure = " << pressure << std::endl;
                     return false;

--- a/src/five_moment/fluid_flux_es_dgsem_operator.h
+++ b/src/five_moment/fluid_flux_es_dgsem_operator.h
@@ -796,6 +796,7 @@ bool FluidFluxESDGSEMOperator<dim>::check_if_solution_is_positive(
             for (unsigned int lane = 0; lane < VectorizedArray<double>::size(); lane++) {
                 if (cell_avg[0][lane] < 0.0 || pressure[lane] < 1e-13) {
                     std::cout << "cell = " << cell << std::endl;
+                    std::cout << "location = " << phi.quadrature_point(0)[0][lane] << ", " << phi.quadrature_point(0)[1][lane] << std::endl;
                     std::cout << "cell_avg = " << cell_avg << std::endl;
                     std::cout << "pressure = " << pressure << std::endl;
                     return false;


### PR DESCRIPTION
This will make the fluid/field coupling calculated in the explicit RK stage, rather than a splitting method.